### PR TITLE
Revert "vlog: fix the godoc formatting"

### DIFF
--- a/vlog/funcs.go
+++ b/vlog/funcs.go
@@ -44,7 +44,23 @@ func V(level Level) bool {
 // interface that will either log (if level >= the configured level)
 // or discard its parameters. This allows for logger.VI(2).Info
 // style usage.
-func VI(level Level) Infoer {
+func VI(level Level) interface {
+	// Info logs to the INFO log.
+	// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+	Info(args ...interface{})
+
+	// Infoln logs to the INFO log.
+	// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+	Infof(format string, args ...interface{})
+
+	// InfoDepth acts as Info but uses depth to determine which call frame to log.
+	// A depth of 0 is equivalent to calling Info.
+	InfoDepth(depth int, args ...interface{})
+
+	// InfoStack logs the current goroutine's stack if the all parameter
+	// is false, or the stacks of all goroutines if it's true.
+	InfoStack(all bool)
+} {
 	if Log.log.VDepth(0, llog.Level(level)) {
 		return Log
 	}

--- a/vlog/log.go
+++ b/vlog/log.go
@@ -240,7 +240,7 @@ func (*discardInfo) Infof(string, ...interface{})  {}
 func (*discardInfo) InfoDepth(int, ...interface{}) {}
 func (*discardInfo) InfoStack(bool)                {}
 
-type Infoer interface {
+func (l *Logger) VI(v int) interface {
 	// Info logs to the INFO log.
 	// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
 	Info(args ...interface{})
@@ -256,16 +256,30 @@ type Infoer interface {
 	// InfoStack logs the current goroutine's stack if the all parameter
 	// is false, or the stacks of all goroutines if it's true.
 	InfoStack(all bool)
-}
-
-func (l *Logger) VI(v int) Infoer {
+} {
 	if l.log.VDepth(0, llog.Level(v)) {
 		return l
 	}
 	return &discardInfo{}
 }
 
-func (l *Logger) VIDepth(depth int, v int) Infoer {
+func (l *Logger) VIDepth(depth int, v int) interface {
+	// Info logs to the INFO log.
+	// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+	Info(args ...interface{})
+
+	// Infoln logs to the INFO log.
+	// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+	Infof(format string, args ...interface{})
+
+	// InfoDepth acts as Info but uses depth to determine which call frame to log.
+	// A depth of 0 is equivalent to calling Info.
+	InfoDepth(depth int, args ...interface{})
+
+	// InfoStack logs the current goroutine's stack if the all parameter
+	// is false, or the stacks of all goroutines if it's true.
+	InfoStack(all bool)
+} {
 	if l.log.VDepth(depth, llog.Level(v)) {
 		return l
 	}


### PR DESCRIPTION
The fix breaks the v23/logging.

This reverts commit 137d4863b72e39b38c545f3d925d55283cca9b32.