### PR TITLE
v.io/x/lib/netstate: relax a check in TestConversions

### DIFF
--- a/netstate/netstate_test.go
+++ b/netstate/netstate_test.go
@@ -91,12 +91,12 @@ func TestConversions(t *testing.T) {
 	// ConvertToAddresses as we pass in.
 	all, _, _ := netstate.GetAllAddresses()
 	lb := all.Filter(netstate.IsLoopbackIP).Filter(netstate.IsUnicastIPv4)
-	if got, want := len(lb), 1; got != want {
-		t.Fatalf("got %v, want %v, all: %v, lb: %v", got, want, all, lb)
+	if got, want := len(lb), 1; got < want {
+		t.Fatalf("got %v, want at lest %v, all: %v, lb: %v", got, want, all, lb)
 	}
 	al = netstate.ConvertToAddresses(lb.AsNetAddrs())
-	if got, want := len(al), 1; got != want {
-		t.Fatalf("got %v, want %v, al: %v", got, want, al)
+	if got, want := len(al), 1; got < want {
+		t.Fatalf("got %v, want at least %v, al: %v", got, want, al)
 	}
 	found := false
 	for _, a := range all {


### PR DESCRIPTION
On my machine (macOS Sierra) there are multiple addresses in the 127.0.0.0/8
space.