### PR TITLE
v.io/x/lib/cmdline: remove dependency on the jiri tool

### DIFF
--- a/cmd/linewrap/doc.go
+++ b/cmd/linewrap/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Vanadium Authors. All rights reserved.
+// Copyright 2018 The Vanadium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmd/linewrap/linewrap.go
+++ b/cmd/linewrap/linewrap.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // The following enables go generate to generate the doc.go file.
-//go:generate go run $JIRI_ROOT/release/go/src/v.io/x/lib/cmdline/testdata/gendoc.go . -h
+//go:generate gendoc . -h
 
 package main
 

--- a/cmdline/gendoc/gendoc.go
+++ b/cmdline/gendoc/gendoc.go
@@ -17,10 +17,7 @@
 // its idiomatic use via "go run".
 //
 // The gendoc command itself is not based on the cmdline library to avoid
-// non-trivial bootstrapping.  In particular, if the compilation of gendoc
-// requires GOPATH to contain the vanadium Go workspaces, then running the
-// gendoc command requires the jiri tool, which in turn may depend on the gendoc
-// command.
+// non-trivial bootstrapping.
 package main
 
 import (
@@ -84,7 +81,7 @@ func generate(args []string) error {
 		pkgs = append(pkgs, strings.Split(flagInstall, ",")...)
 	}
 
-	installCmd := append([]string{}, "jiri", "go", "install")
+	installCmd := append([]string{}, "go", "install")
 	if len(goInstallCommand) > 0 {
 		installCmd = strings.Split(goInstallCommand, " ")
 	}
@@ -114,7 +111,7 @@ func generate(args []string) error {
 		tagsConstraint = fmt.Sprintf("// +build %s\n\n", flagTags)
 	}
 
-	copyright := `// Copyright 2017 The Vanadium Authors. All rights reserved.
+	copyright := `// Copyright 2018 The Vanadium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
Remove the dependency on the jiri tool and instead rely on gendoc being installed in a directory accessible via PATH.