### PR TITLE
x/lib/netconfig: refactor packages to work with bazel go_rules

### DIFF
--- a/netconfig/osnetconfig/common.go
+++ b/netconfig/osnetconfig/common.go
@@ -1,0 +1,55 @@
+package osnetconfig
+
+// Force this file to compile as cgo, to work around bazel/rules_go
+// limitations. See also https://github.com/bazelbuild/rules_go/issues/255
+
+import "C"
+import (
+	"sync"
+	"time"
+)
+
+type notifier struct {
+	sync.Mutex
+	ch    chan struct{}
+	timer *time.Timer
+
+	initErr error
+	inited  bool
+}
+
+func (n *notifier) add() (<-chan struct{}, error) {
+	n.Lock()
+	defer n.Unlock()
+	if !n.inited {
+		n.ch = make(chan struct{})
+		n.initErr = n.initLocked()
+		n.inited = true
+	}
+	if n.initErr != nil {
+		return nil, n.initErr
+	}
+	return n.ch, nil
+}
+
+func (n *notifier) ding() {
+	// Changing networks usually spans many seconds and involves
+	// multiple network config changes.  We add histeresis by
+	// setting an alarm when the first change is detected and
+	// not informing the client till the alarm goes off.
+	// NOTE(p): I chose 3 seconds because that covers all the
+	// events involved in moving from one wifi network to another.
+	n.Lock()
+	if n.timer == nil {
+		n.timer = time.AfterFunc(3*time.Second, n.resetChan)
+	}
+	n.Unlock()
+}
+
+func (n *notifier) resetChan() {
+	n.Lock()
+	close(n.ch)
+	n.ch = make(chan struct{})
+	n.timer = nil
+	n.Unlock()
+}

--- a/netconfig/osnetconfig/ipaux_bsd.go
+++ b/netconfig/osnetconfig/ipaux_bsd.go
@@ -4,7 +4,7 @@
 
 // +build darwin dragonfly freebsd netbsd openbsd
 
-package netconfig
+package osnetconfig
 
 // We connect to the Route socket and parse messages to
 // look for network configuration changes.  This is generic
@@ -18,6 +18,7 @@ import (
 	"net"
 	"syscall"
 
+	"v.io/x/lib/netconfig"
 	"v.io/x/lib/vlog"
 )
 
@@ -93,8 +94,8 @@ func toIPNet(sa syscall.Sockaddr, msa syscall.Sockaddr) (net.IPNet, error) {
 
 // IPRoutes returns all kernel known routes.  If defaultOnly is set, only default routes
 // are returned.
-func GetIPRoutes(defaultOnly bool) []*IPRoute {
-	var x []*IPRoute
+func (n *notifier) GetIPRoutes(defaultOnly bool) []*netconfig.IPRoute {
+	var x []*netconfig.IPRoute
 	rib, err := syscall.RouteRIB(syscall.NET_RT_DUMP, 0)
 	if err != nil {
 		vlog.Infof("Couldn't read: %s", err)
@@ -115,7 +116,7 @@ func GetIPRoutes(defaultOnly bool) []*IPRoute {
 			if addrs[0] == nil || addrs[1] == nil || addrs[2] == nil {
 				continue
 			}
-			r := new(IPRoute)
+			r := new(netconfig.IPRoute)
 			if r.Gateway, err = toIP(addrs[1]); err != nil {
 				continue
 			}
@@ -123,7 +124,7 @@ func GetIPRoutes(defaultOnly bool) []*IPRoute {
 				continue
 			}
 			r.IfcIndex = int(v.Header.Index)
-			if !defaultOnly || IsDefaultIPRoute(r) {
+			if !defaultOnly || netconfig.IsDefaultIPRoute(r) {
 				x = append(x, r)
 			}
 		}

--- a/netconfig/osnetconfig/ipaux_linux.go
+++ b/netconfig/osnetconfig/ipaux_linux.go
@@ -267,7 +267,7 @@ func (n *notifier) initLocked() error {
 	lsa := &syscall.SockaddrNetlink{Family: syscall.AF_NETLINK, Groups: GROUPS}
 	if err := syscall.Bind(s, lsa); err != nil {
 		syscall.Close(s)
-		return fmt.Errorf("bind(%d, {AF_NETLINK, 0x%x}) failed: %v", s, lsa.Groups)
+		return fmt.Errorf("bind(%d, {AF_NETLINK, 0x%x}) failed: %v", s, lsa.Groups, err)
 	}
 	go watcher(n, s)
 	return nil

--- a/netconfig/osnetconfig/ipaux_other.go
+++ b/netconfig/osnetconfig/ipaux_other.go
@@ -5,7 +5,12 @@
 // +build !linux,!darwin,!dragonfly,!freebsd,!netbsd,!openbsd
 // TODO(bprosnitz) Should change for nacl?
 
-package netconfig
+package osnetconfig
+
+// Force this file to compile as cgo, to work around bazel/rules_go
+// limitations. See also https://github.com/bazelbuild/rules_go/issues/255
+
+import "C"
 
 // Code to signal a network change every 2 minutes.   We use
 // this for systems where we don't yet have a good way to
@@ -15,7 +20,7 @@ import (
 	"time"
 )
 
-func (n *notifier) initLocked() error {
+func (n *notifier) InitLocked() error {
 	go func() {
 		ticker := time.Tick(2 * time.Minute)
 		for range ticker {
@@ -25,8 +30,8 @@ func (n *notifier) initLocked() error {
 	return nil
 }
 
-func GetIPRoutes(defaultOnly bool) []*IPRoute {
+func (n *notifier) GetIPRoutes(defaultOnly bool) []*netconfig.IPRoute {
 	// TODO(nlacasse,bprosnitz): Consider implementing? For now return
 	// empty array, since that seems to keep things working.
-	return []*IPRoute{}
+	return []*netconfig.IPRoute{}
 }


### PR DESCRIPTION
Refactor netconfig into two packages to work around bazel/rules_go limitations. See the comment in
osnetconfig/common.go.
