### PR TITLE
lib/cmd/flagvar: allow for struct embedding

### DIFF
--- a/cmd/flagvar/flagvar.go
+++ b/cmd/flagvar/flagvar.go
@@ -113,7 +113,7 @@ func ParseFlagTag(t string) (name, value, usage string, err error) {
 func literalDefault(typeName, literal string, initialValue interface{}) (value interface{}, err error) {
 	if initialValue != nil {
 		switch v := initialValue.(type) {
-		case int, int64, uint, uint64, bool, float64, time.Duration:
+		case int, int64, uint, uint64, bool, float64, string, time.Duration:
 			value = v
 			return
 		}

--- a/cmd/flagvar/flagvar_test.go
+++ b/cmd/flagvar/flagvar_test.go
@@ -195,8 +195,9 @@ func TestRegister(t *testing.T) {
 	}{}
 
 	values := map[string]interface{}{
-		"iv": 33,
-		"u":  runtime.NumCPU(),
+		"iv":     33,
+		"u":      runtime.NumCPU(),
+		"str-nq": "oh my",
 	}
 
 	usageDefaults := map[string]string{
@@ -256,7 +257,7 @@ func TestRegister(t *testing.T) {
 	assert(s1.F, true)
 	assert(s1.G, 2*time.Second)
 	assert(s1.HQ, "xx,yy")
-	assert(s1.HNQ, "xxyy")
+	assert(s1.HNQ, "oh my")
 	assert(s1.V, myFlagVar(22))
 	assert(s1.X, myFlagVar(33))
 

--- a/cmd/flagvar/flagvar_test.go
+++ b/cmd/flagvar/flagvar_test.go
@@ -74,7 +74,9 @@ func TestTags(t *testing.T) {
 		{"nn,,u", "nn", "", "u", ""},
 		{"'n,n',,u", "n,n", "", "u", ""},
 		{"n,,yy", "n", "", "yy", ""},
+		{"n,,yy\\'s", "n", "", "yy's", ""},
 		{"n,'xx,yy',usage", "n", "xx,yy", "usage", ""},
+		{"n,'xx,yy','usage, more'", "n", "xx,yy", "usage, more", ""},
 		{"n,'xx,yy',aa,bb", "n", "xx,yy", "aa,bb", "spurious text after <usage>"},
 		{"n,xx,aa,bb", "n", "xx", "yy,zz", "spurious text after <usage>"},
 	} {

--- a/cmdline/cmdline.go
+++ b/cmdline/cmdline.go
@@ -122,9 +122,9 @@ type Command struct {
 // FlagDefinitions represents a struct containing flag variables and their
 // associated default values as per RegisterFlagsInStruct.
 type FlagDefinitions struct {
-	StructWithFlags interface{}
-	ValueDefaults   map[string]interface{}
-	UsageDefaults   map[string]string
+	Flags         interface{}
+	ValueDefaults map[string]interface{}
+	UsageDefaults map[string]string
 }
 
 // Runner is the interface for running commands.  Return ErrExitCode to indicate
@@ -430,7 +430,7 @@ func (cmd *Command) parse(path []*Command, env *Env, args []string, setFlags map
 }
 
 func (cmd *Command) registerFlagDefs() error {
-	if fs := cmd.FlagDefs.StructWithFlags; fs != nil {
+	if fs := cmd.FlagDefs.Flags; fs != nil {
 		err := flagvar.RegisterFlagsInStruct(&cmd.Flags, "cmdline", fs, cmd.FlagDefs.ValueDefaults, cmd.FlagDefs.UsageDefaults)
 		if err != nil {
 			return fmt.Errorf("command: %v: %v", cmd.Name, err)

--- a/cmdline/flagdef_test.go
+++ b/cmdline/flagdef_test.go
@@ -17,7 +17,7 @@ func TestFlagVarIntegration(t *testing.T) {
 	}{}
 	cmd := &cmdline.Command{
 		Name:     "test",
-		FlagDefs: cmdline.FlagDefinitions{StructWithFlags: &s1},
+		FlagDefs: cmdline.FlagDefinitions{Flags: &s1},
 		Runner:   &runner{},
 	}
 	_, _, err := cmdline.Parse(cmd, cmdline.EnvFromOS(), []string{"--int-var=33"})
@@ -30,11 +30,11 @@ func TestFlagVarIntegration(t *testing.T) {
 
 	cmd = &cmdline.Command{
 		Name:     "test",
-		FlagDefs: cmdline.FlagDefinitions{StructWithFlags: &s1},
+		FlagDefs: cmdline.FlagDefinitions{Flags: &s1},
 	}
 	cmd.Children = append(cmd.Children, &cmdline.Command{
 		Name:     "child1",
-		FlagDefs: cmdline.FlagDefinitions{StructWithFlags: &s1},
+		FlagDefs: cmdline.FlagDefinitions{Flags: &s1},
 		Runner:   &runner{},
 	})
 


### PR DESCRIPTION
Allow for struct embedding so that common flags can be easily re-used:

type CommonFlags struct {
   A int `cmdline:"a,,use a"`
   B int `cmdline:"b,,use b"`
}
flagSet := struct{
   CommonFlags
   C bool `cmdline:"c,,use c"`
}

// will result in three flags, --a, --b and --c.
