### PR TITLE
nsync: disable the stress test in Travis CI

### DIFF
--- a/nsync/cv_timeout_stress_test.go
+++ b/nsync/cv_timeout_stress_test.go
@@ -4,6 +4,8 @@
 
 // This test runs too slowly under the race detector.
 // +build !race
+// This test is flaky on Travis CI.
+// +build !travis
 
 package nsync_test
 


### PR DESCRIPTION
This assumes that the test under Travis CI are run using `-tags travis`
for the `go test` invocations.