### PR TITLE
cmd/flagvar: allow defaults to include shell variables

### DIFF
--- a/cmd/flagvar/flagvar_test.go
+++ b/cmd/flagvar/flagvar_test.go
@@ -7,6 +7,7 @@ package flagvar_test
 import (
 	"flag"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -24,6 +25,7 @@ func ExampleRegisterFlagsInStruct() {
 		A int    `flag:"int-flag,-1,intVar flag"`
 		B string `flag:"string-flag,'some,value,with,a,comma',stringVar flag"`
 		O int
+		H string `flag:"config,$HOME/config,config file in home directotyr"`
 	}{
 		O: 23,
 	}
@@ -34,9 +36,12 @@ func ExampleRegisterFlagsInStruct() {
 	}
 	fmt.Println(eg.A)
 	fmt.Println(eg.B)
-	flagSet.Parse([]string{"-int-flag=42"})
+	flagSet.Parse([]string{"--int-flag=42"})
 	fmt.Println(eg.A)
 	fmt.Println(eg.B)
+	if got, want := eg.H, filepath.Join(os.Getenv("HOME"), "config"); got != want {
+		fmt.Printf("got %v, want %v", got, want)
+	}
 	// Output:
 	// -1
 	// some,value,with,a,comma
@@ -117,6 +122,19 @@ func allFlags(fs *flag.FlagSet) string {
 	})
 	sort.Strings(out)
 	return strings.Join(out, "\n")
+}
+
+func MaxProcs() int {
+	return runtime.GOMAXPROCS(-1)
+}
+
+func CurrentDirectory() string {
+	d, _ := os.Getwd()
+	return d
+}
+
+func OneHour() time.Duration {
+	return time.Hour
 }
 
 func TestRegister(t *testing.T) {
@@ -292,6 +310,41 @@ func TestRegister(t *testing.T) {
 	assert(s1.V, myFlagVar(42))
 	assert(s1.X, myFlagVar(12))
 
+	os.Setenv("ENV_INT_TESTING", "0")
+	// Test shell variable expansion and functions.
+	s2 := struct {
+		A string `cmdline:"configA,$HOME/.config,config flag"`
+		B string `cmdline:"configB,$HOME/.config,config flag"`
+		C string `cmdline:"configC,$HOME/.config,config flag"`
+		D int    `cmdline:"exitCode,$ENV_INT_TESTING,an integer environment variable"`
+	}{}
+	values = map[string]interface{}{
+		"configB": "something-else",
+	}
+	usageDefaults = map[string]string{
+		"configC": "override",
+	}
+
+	expectedUsage = []string{
+		`cmdline:"configA,$HOME/.config,config flag"`,
+		`cmdline:"configB,something-else,config flag"`,
+		`cmdline:"configC,override,config flag"`,
+		`cmdline:"exitCode,$ENV_INT_TESTING,an integer environment variable"`,
+	}
+	sort.Strings(expectedUsage)
+
+	fs = &flag.FlagSet{}
+	err = flagvar.RegisterFlagsInStruct(fs, "cmdline", &s2, values, usageDefaults)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if got, want := allFlags(fs), strings.Join(expectedUsage, "\n"); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	assert(strings.Contains(s2.A, "$HOME"), false)
+	assert(s2.B, "something-else")
+	assert(strings.Contains(s2.C, "$HOME"), false)
+	assert(s2.D >= 0, true)
 }
 
 func TestErrors(t *testing.T) {


### PR DESCRIPTION
This PR adds the ability to use environment variables as default values when specifying flags. This makes it easy to refer to $HOME/.config. The default value will be the expanded value, of, in this case, $HOME/.config, whereas the usage value will be $HOME/.config and not the expanded version.